### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The FlexSlider module allows a developer to attach a [Woothemes FlexSlider](http
 
 ## Installation
 
-`composer require dynamic/silverstripe-flexslider dev-master`
+`composer require dynamic/flexslider dev-master`
 
 Add `flexslider` to your `.gitignore`
 


### PR DESCRIPTION
Updated composer installation instruction with the [correct name](https://packagist.org/packages/dynamic/flexslider)

FIXES: 

> The requested package dynamic/silverstripe-flexslider could not be found in any version, there may be a typo in the package name.