### PR TITLE
Add config to disable Requirements::customScript

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -17,6 +17,7 @@ Page:
 After attaching the DataExtension to your page type or DataObject run a `dev/build`.
 
 #### Adjust slider speed
+
 Adding `FlexSliderSpeed` to the config will adjust the speed of the slider in milliseconds.
 Sliders default to 7000 milliseconds, or 7 seconds to show each slide.
 
@@ -27,9 +28,10 @@ Page:
     - Dynamic\FlexSlider\ORM\FlexSlider
 ```
 
-The object that has FlexSlider applied can also have a method `setFlexSliderSpeed()`. 
+The object that has FlexSlider applied can also have a method `setFlexSliderSpeed()`.
 This will allow for a field to be added to the cms to control speed, or more fine grained control over the speed of the slider.
 If `setFlexSliderSpeed()` return 0 or false the slider will fall back to using the config value.
+
 ```php
 public function setFlexSliderSpeed()
 {
@@ -38,9 +40,17 @@ public function setFlexSliderSpeed()
 ```
 
 Adjusting the defualt for all sliders can also be done in the config.
+
 ```yml
 Dynamic\FlexSlider\ORM\FlexSlider:
   FlexSliderSpeed: 3000
+```
+
+To disable including the custom JavaScript, use the `ClearRequirements` configuration:
+
+```yml
+Dynamic\FlexSlider\ORM\FlexSlider:
+  ClearRequirements: true
 ```
 
 ### User Guide

--- a/src/ORM/FlexSlider.php
+++ b/src/ORM/FlexSlider.php
@@ -205,6 +205,11 @@ class FlexSlider extends DataExtension
      */
     public function getCustomScript()
     {
+
+        if($this->owner()->config('ClearRequirements')) {
+            return;
+        }
+
         // Flexslider options
         $sync = ($this->owner->ThumbnailNav == true) ? "sync: '.fs-carousel:eq('+index+')'," : '';
 
@@ -222,13 +227,13 @@ class FlexSlider extends DataExtension
             "(function($) {
                 $(document).ready(function(){
                     jQuery('.flexslider').each(function(index){
-					 
+
                          if(jQuery('.fs-carousel').eq(index).length) {
                              jQuery('.fs-carousel').eq(index).flexslider({
                                 slideshow: " . $this->owner->obj('Animate')->NiceAsBoolean() . ",
                                 animation: 'slide',
                                 animationLoop: " . $this->owner->obj('Loop')->NiceAsBoolean() . ",
-                                controlNav: " . $this->owner->obj('CarouselControlNav')->NiceAsBoolean() . ", 
+                                controlNav: " . $this->owner->obj('CarouselControlNav')->NiceAsBoolean() . ",
                                 directionNav: " . $this->owner->obj('CarouselDirectionNav')->NiceAsBoolean() . ",
                                 prevText: '',
                                 nextText: '',
@@ -241,7 +246,7 @@ class FlexSlider extends DataExtension
                                 itemMargin: 10
                               });
                          }
- 
+
                         if(jQuery('.flexslider').eq(index).length){
                             jQuery('.flexslider').eq(index).flexslider({
                                 slideshow: " . $this->owner->obj('Animate')->NiceAsBoolean() . ",
@@ -259,7 +264,7 @@ class FlexSlider extends DataExtension
                                 },
                                 before: " . $before . ',
                                 after: ' . $after . ',
-                                slideshowSpeed: ' . $speed . ' 
+                                slideshowSpeed: ' . $speed . '
                             });
                         }
                     })

--- a/src/ORM/FlexSlider.php
+++ b/src/ORM/FlexSlider.php
@@ -269,7 +269,8 @@ class FlexSlider extends DataExtension
                         }
                     })
                 });
-            }(jQuery));'
+            }(jQuery));',
+            'flexsliderjquery'
         );
     }
 


### PR DESCRIPTION
I am including the `silverstripe/elemental-flexslider` but am using completely my own templates and all the frontend code. I have no way to exclude the custom JS required with this module. I also think a configuration is a simpler step than clearing the requirement. I've added a custom ID to the custom require, as per best practice - but fyi, clearing that in a PageController did not work.