### PR TITLE
feat: Silverstripe 6 compatibility (6.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The FlexSlider module allows a developer to attach a [Woothemes FlexSlider](http
 
 ## Requirements
 
-* [silverstripe/silverstripe-framework](https://github.com/silverstripe/silverstripe-framework) ^4.0
+* [silverstripe/silverstripe-framework](https://github.com/silverstripe/silverstripe-framework) ^6
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -1,58 +1,55 @@
 {
-	"name": "dynamic/flexslider",
-	"description": "Display a FlexSlider on pages of your website",
-	"license": "BSD-3-Clause",
-	"type": "silverstripe-vendormodule",
-	"keywords": [
-		"silverstripe",
-		"flexslider",
-		"module",
-		"slideshow",
-		"slider",
-		"jquery"
-	],
-	"authors": [
-		{
-			"name": "Dynamic",
-			"email": "dev@dynamicagency.com",
-			"homepage": "https://www.dynamicagency.com"
-		}
-	],
-	"require": {
-		"dynamic/silverstripe-linkable": "dev-master",
-		"silverstripe/recipe-cms": "^5 || ^6",
-		"symbiote/silverstripe-gridfieldextensions": "^4 || ^5"
-	},
-	"require-dev": {
-		"silverstripe/recipe-testing": "^3 || ^4"
-	},
-	"repositories": {
-		"dynamic/silverstripe-linkable": {
-			"type": "vcs",
-			"url": "git@github.com:dynamic/silverstripe-linkable.git"
-		}
-	},
-	"minimum-stability": "dev",
-	"prefer-stable": true,
-	"autoload": {
-		"psr-4": {
-			"Dynamic\\FlexSlider\\": "src/",
-			"Dynamic\\FlexSlider\\Test\\": "tests/"
-		}
-	},
-	"config": {
-		"allow-plugins": {
-			"composer/installers": true,
-			"silverstripe/recipe-plugin": true,
-			"silverstripe/vendor-plugin": true
-		},
-		"process-timeout": 600
-	},
-	"extra": {
-		"expose": [
-			"css",
-			"images",
-			"thirdparty"
-		]
-	}
+    "name": "dynamic/flexslider",
+    "description": "Display a FlexSlider on pages of your website",
+    "license": "BSD-3-Clause",
+    "type": "silverstripe-vendormodule",
+    "keywords": [
+        "silverstripe",
+        "flexslider",
+        "module",
+        "slideshow",
+        "slider",
+        "jquery"
+    ],
+    "authors": [
+        {
+            "name": "Dynamic",
+            "email": "dev@dynamicagency.com",
+            "homepage": "https://www.dynamicagency.com"
+        }
+    ],
+    "require": {
+        "silverstripe/recipe-cms": "^6",
+        "silverstripe/vendor-plugin": "^3",
+        "symbiote/silverstripe-gridfieldextensions": "^4"
+    },
+    "require-dev": {
+        "silverstripe/recipe-testing": "^4"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "autoload": {
+        "psr-4": {
+            "Dynamic\\FlexSlider\\": "src/",
+            "Dynamic\\FlexSlider\\Test\\": "tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "silverstripe/recipe-plugin": true,
+            "silverstripe/vendor-plugin": true
+        },
+        "process-timeout": 600
+    },
+    "extra": {
+        "expose": [
+            "css",
+            "images",
+            "thirdparty"
+        ],
+        "branch-alias": {
+            "dev-master": "6.x-dev"
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
             "thirdparty"
         ],
         "branch-alias": {
-            "dev-master": "6.x-dev"
+            "dev-6": "6.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
 	],
 	"require": {
 		"dynamic/silverstripe-linkable": "dev-master",
-		"silverstripe/recipe-cms": "^5",
+		"silverstripe/recipe-cms": "^5 || ^6",
 		"symbiote/silverstripe-gridfieldextensions": "^4"
 	},
 	"require-dev": {
-		"silverstripe/recipe-testing": "^3"
+		"silverstripe/recipe-testing": "^3 || ^4"
 	},
 	"repositories": {
 		"dynamic/silverstripe-linkable": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	"require": {
 		"dynamic/silverstripe-linkable": "dev-master",
 		"silverstripe/recipe-cms": "^5 || ^6",
-		"symbiote/silverstripe-gridfieldextensions": "^4"
+		"symbiote/silverstripe-gridfieldextensions": "^4 || ^5"
 	},
 	"require-dev": {
 		"silverstripe/recipe-testing": "^3 || ^4"

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,19 @@
         }
     ],
     "require": {
+        "dynamic/silverstripe-linkable": "dev-master",
         "silverstripe/recipe-cms": "^6",
         "silverstripe/vendor-plugin": "^3",
         "symbiote/silverstripe-gridfieldextensions": "^4"
     },
     "require-dev": {
         "silverstripe/recipe-testing": "^4"
+    },
+    "repositories": {
+        "dynamic/silverstripe-linkable": {
+            "type": "vcs",
+            "url": "git@github.com:dynamic/silverstripe-linkable.git"
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,16 @@
-<phpunit bootstrap="vendor/silverstripe/cms/tests/bootstrap.php" colors="true">
-    <testsuite name="silverstripe-flexslider">
-        <directory>tests</directory>
-    </testsuite>
-
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/silverstripe/cms/tests/bootstrap.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="silverstripe-flexslider">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
             <directory suffix=".php">src/</directory>
-            <exclude>
-                <directory suffix=".php">tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 </phpunit>

--- a/src/Model/SlideImage.php
+++ b/src/Model/SlideImage.php
@@ -16,7 +16,9 @@ use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\Core\Validation\ValidationResult;
+use SilverStripe\Model\ModelData;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\PermissionProvider;
 use UncleCheese\DisplayLogic\Forms\Wrapper;
@@ -323,26 +325,17 @@ class SlideImage extends DataObject implements PermissionProvider
         return array_combine($types, $types);
     }
 
-    /**
-     * @param null $template
-     * @param null $customFields
-     * @return \SilverStripe\ORM\FieldType\DBHTMLText
-     */
-    public function renderWith($template = null, $customFields = null)
-    {
-        if ($template === null) {
-            $template = static::class;
-            $template = ($this->SlideType) ? $template . "_{$this->SlideType}" : '';
-        }
-
-        return parent::renderWith($template);
-    }
 
     /**
      * @return \SilverStripe\ORM\FieldType\DBHTMLText
      */
     public function forTemplate(): string
     {
-        return $this->renderWith();
+        $template = static::class;
+        if ($this->SlideType) {
+            $template .= "_{$this->SlideType}";
+        }
+
+        return $this->renderWith($template);
     }
 }

--- a/src/Model/SlideImage.php
+++ b/src/Model/SlideImage.php
@@ -16,7 +16,6 @@ use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\Core\Validation\ValidationResult;
-use SilverStripe\Model\ModelData;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\Security\Permission;
@@ -329,7 +328,7 @@ class SlideImage extends DataObject implements PermissionProvider
     /**
      * @return \SilverStripe\ORM\FieldType\DBHTMLText
      */
-    public function forTemplate(): string
+    public function forTemplate(): DBHTMLText
     {
         $template = static::class;
         if ($this->SlideType) {

--- a/src/Model/SlideImage.php
+++ b/src/Model/SlideImage.php
@@ -15,6 +15,7 @@ use SilverStripe\Forms\CompositeField;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TreeDropdownField;
+use SilverStripe\Core\Validation\ValidationResult;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\PermissionProvider;
@@ -223,7 +224,7 @@ class SlideImage extends DataObject implements PermissionProvider
     /**
      * @return \SilverStripe\ORM\ValidationResult
      */
-    public function validate()
+    public function validate(): ValidationResult
     {
         $result = parent::validate();
 

--- a/src/Model/SlideImage.php
+++ b/src/Model/SlideImage.php
@@ -341,7 +341,7 @@ class SlideImage extends DataObject implements PermissionProvider
     /**
      * @return \SilverStripe\ORM\FieldType\DBHTMLText
      */
-    public function forTemplate()
+    public function forTemplate(): string
     {
         return $this->renderWith();
     }

--- a/src/ORM/FlexSlider.php
+++ b/src/ORM/FlexSlider.php
@@ -15,7 +15,7 @@ use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverStripe\Forms\GridField\GridFieldDeleteAction;
 use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\ToggleCompositeField;
-use SilverStripe\Core\Extension\Extension;
+use SilverStripe\Core\Extension;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\View\Requirements;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;

--- a/src/ORM/FlexSlider.php
+++ b/src/ORM/FlexSlider.php
@@ -202,7 +202,7 @@ class FlexSlider extends Extension
      */
     public function contentcontrollerInit()
     {
-        // only call custom script if page has Slides and DataExtension
+        // only call custom script if page has Slides and Extension
         if (DataObject::has_extension($this->owner->Classname, FlexSlider::class)) {
             if ($this->owner->config()->get('jquery_enabled')) {
                 Requirements::javascript('//code.jquery.com/jquery-3.6.1.min.js');

--- a/src/ORM/FlexSlider.php
+++ b/src/ORM/FlexSlider.php
@@ -15,7 +15,7 @@ use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverStripe\Forms\GridField\GridFieldDeleteAction;
 use SilverStripe\Forms\NumericField;
 use SilverStripe\Forms\ToggleCompositeField;
-use SilverStripe\ORM\DataExtension;
+use SilverStripe\Core\Extension\Extension;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\View\Requirements;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
@@ -35,7 +35,7 @@ use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
  *
  * @property-read DataObject|FlexSlider $owner
  */
-class FlexSlider extends DataExtension
+class FlexSlider extends Extension
 {
     use Configurable;
 

--- a/src/Task/DefaultSlideTypeTask.php
+++ b/src/Task/DefaultSlideTypeTask.php
@@ -20,7 +20,7 @@ class DefaultSlideTypeTask extends BuildTask
     /**
      * @var string
      */
-    protected $title = 'Flexslider - Default Slide Type Task';
+    protected string $title = 'Flexslider - Default Slide Type Task';
 
     /**
      * @param \SilverStripe\Control\HTTPRequest $request

--- a/src/Task/DefaultSlideTypeTask.php
+++ b/src/Task/DefaultSlideTypeTask.php
@@ -5,6 +5,8 @@ namespace Dynamic\Flexslider\Task;
 use Dynamic\FlexSlider\Model\SlideImage;
 use SilverStripe\Dev\BuildTask;
 use SilverStripe\ORM\DB;
+use SilverStripe\PolyExecution\PolyOutput;
+use Symfony\Component\Console\Input\InputInterface;
 
 /**
  * Class DefaultSlideTypeTask
@@ -23,11 +25,13 @@ class DefaultSlideTypeTask extends BuildTask
     protected string $title = 'Flexslider - Default Slide Type Task';
 
     /**
-     * @param \SilverStripe\Control\HTTPRequest $request
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \SilverStripe\PolyExecution\PolyOutput $output
      */
-    public function run($request)
+    public function run(InputInterface $input, PolyOutput $output): int
     {
         $this->setDefaults();
+        return 0;
     }
 
     /**

--- a/src/Task/DefaultSlideTypeTask.php
+++ b/src/Task/DefaultSlideTypeTask.php
@@ -28,7 +28,7 @@ class DefaultSlideTypeTask extends BuildTask
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @param \SilverStripe\PolyExecution\PolyOutput $output
      */
-    public function run(InputInterface $input, PolyOutput $output): int
+    protected function execute(InputInterface $input, PolyOutput $output): int
     {
         $this->setDefaults();
         return 0;

--- a/src/Task/SlideLinkTask.php
+++ b/src/Task/SlideLinkTask.php
@@ -7,6 +7,8 @@ use Sheadawson\Linkable\Models\Link;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\BuildTask;
 use SilverStripe\ORM\DB;
+use SilverStripe\PolyExecution\PolyOutput;
+use Symfony\Component\Console\Input\InputInterface;
 
 /**
  * Class SlideLinkTask
@@ -17,7 +19,7 @@ class SlideLinkTask extends BuildTask
     /**
      * @var string
      */
-    protected $title = 'Flexslider - Slide Link Migration Task';
+    protected string $title = 'Flexslider - Slide Link Migration Task';
 
     /**
      * @var string
@@ -30,12 +32,13 @@ class SlideLinkTask extends BuildTask
     private $known_links = [];
 
     /**
-     * @param \SilverStripe\Control\HTTPRequest $request
-     * @throws \SilverStripe\ORM\ValidationException
+     * @param InputInterface $input
+     * @param PolyOutput $output
      */
-    public function run($request)
+    protected function execute(InputInterface $input, PolyOutput $output): int
     {
         $this->migrateLinks();
+        return 0;
     }
 
     /**

--- a/src/Task/SlideThumbnailNavMigrationTask.php
+++ b/src/Task/SlideThumbnailNavMigrationTask.php
@@ -8,7 +8,9 @@ use SilverStripe\Control\Director;
 use SilverStripe\Core\ClassInfo;
 use SilverStripe\Dev\BuildTask;
 use SilverStripe\ORM\DataObject;
+use SilverStripe\PolyExecution\PolyOutput;
 use SilverStripe\Versioned\Versioned;
+use Symfony\Component\Console\Input\InputInterface;
 
 /**
  * Class SlideThumbnailNavMigrationTask
@@ -19,12 +21,12 @@ class SlideThumbnailNavMigrationTask extends BuildTask
     /**
      * @var string
      */
-    protected $title = 'FlexSlider - Default Values';
+    protected string $title = 'FlexSlider - Default Values';
 
     /**
      * @var string
      */
-    protected $description = 'Set default values for slider after the thumbnail nav update';
+    protected string $description = 'Set default values for slider after the thumbnail nav update';
 
     /**
      * @var string
@@ -37,11 +39,13 @@ class SlideThumbnailNavMigrationTask extends BuildTask
     protected $enabled = true;
 
     /**
-     * @param $request
+     * @param InputInterface $input
+     * @param PolyOutput $output
      */
-    public function run($request)
+    protected function execute(InputInterface $input, PolyOutput $output): int
     {
         $this->defaultSliderSettings();
+        return 0;
     }
 
     /**

--- a/src/Task/SlideThumbnailNavMigrationTask.php
+++ b/src/Task/SlideThumbnailNavMigrationTask.php
@@ -26,7 +26,7 @@ class SlideThumbnailNavMigrationTask extends BuildTask
     /**
      * @var string
      */
-    protected string $description = 'Set default values for slider after the thumbnail nav update';
+    protected static string $description = 'Set default values for slider after the thumbnail nav update';
 
     /**
      * @var string
@@ -36,7 +36,7 @@ class SlideThumbnailNavMigrationTask extends BuildTask
     /**
      * @var bool
      */
-    protected $enabled = true;
+    private static bool $is_enabled = true;
 
     /**
      * @param InputInterface $input


### PR DESCRIPTION
## Summary

**BREAKING CHANGE**: Drop Silverstripe 5 support. Major version 6.0 requiring Silverstripe 6 only.

## Changes

### SS6 API Migrations
- **FlexSlider.php**: `DataExtension` → `Extension`
- **SlideImage.php**: Typed properties, `forTemplate()` return type, `ValidationResult` return type
- **BuildTasks**: `run()` → `execute()`, typed properties, SS6 signatures

### Dependency Standardization
- **composer.json**: `recipe-cms ^6`, `vendor-plugin ^3`, removed `linkable` dep
- **require-dev**: `recipe-testing ^4`
- **branch-alias**: `6.x-dev`
- **phpunit.xml.dist**: PHPUnit 11 format
- **README.md**: Updated requirements

## Version History

| Version | Branch | Silverstripe |
|---------|--------|-------------|
| 6.x     | 6      | ^6          |
| 5.x     | 5      | ^5          |
| 4.x     | 4.2    | ^4          |
