### PR TITLE
fix: SS6 dependency constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,7 @@
     "require-dev": {
         "silverstripe/recipe-testing": "^4"
     },
-    "repositories": {
-        "dynamic/silverstripe-linkable": {
-            "type": "vcs",
-            "url": "git@github.com:dynamic/silverstripe-linkable.git"
-        }
-    },
+
     "minimum-stability": "dev",
     "prefer-stable": true,
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
         }
     ],
     "require": {
-        "dynamic/silverstripe-linkable": "dev-master",
+        "dynamic/silverstripe-linkable": "^3.0",
         "silverstripe/recipe-cms": "^6",
         "silverstripe/vendor-plugin": "^3",
-        "symbiote/silverstripe-gridfieldextensions": "^4"
+        "symbiote/silverstripe-gridfieldextensions": "^5"
     },
     "require-dev": {
         "silverstripe/recipe-testing": "^4"
@@ -42,11 +42,6 @@
         }
     },
     "config": {
-        "allow-plugins": {
-            "composer/installers": true,
-            "silverstripe/recipe-plugin": true,
-            "silverstripe/vendor-plugin": true
-        },
         "process-timeout": 600
     },
     "extra": {


### PR DESCRIPTION
## Bug

`gridfieldextensions ^4` requires `vendor-plugin ^2`, which conflicts with SS6's `vendor-plugin ^3`. This prevents `composer update` from resolving in the main project.

## Fix
- `symbiote/silverstripe-gridfieldextensions`: `^4` → `^5` (5.2.0 is SS6-compatible)
- `dynamic/silverstripe-linkable`: `dev-master` → `^3.0` (tagged release)
- Removed module-level `allow-plugins` (handled by root project)