### PR TITLE
fix: forTemplate() return type for SS6 compatibility

### DIFF
--- a/src/Model/SlideImage.php
+++ b/src/Model/SlideImage.php
@@ -17,7 +17,6 @@ use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\TreeDropdownField;
 use SilverStripe\Core\Validation\ValidationResult;
 use SilverStripe\ORM\DataObject;
-use SilverStripe\ORM\FieldType\DBHTMLText;
 use SilverStripe\Security\Permission;
 use SilverStripe\Security\PermissionProvider;
 use UncleCheese\DisplayLogic\Forms\Wrapper;
@@ -326,15 +325,15 @@ class SlideImage extends DataObject implements PermissionProvider
 
 
     /**
-     * @return \SilverStripe\ORM\FieldType\DBHTMLText
+     * @return string
      */
-    public function forTemplate(): DBHTMLText
+    public function forTemplate(): string
     {
         $template = static::class;
         if ($this->SlideType) {
             $template .= "_{$this->SlideType}";
         }
 
-        return $this->renderWith($template);
+        return (string) $this->renderWith($template);
     }
 }


### PR DESCRIPTION
## Bug

CI fails with:
```
PHP Fatal error: Declaration of Dynamic\FlexSlider\Model\SlideImage::forTemplate(): 
SilverStripe\ORM\FieldType\DBHTMLText must be compatible with 
SilverStripe\Model\ModelData::forTemplate(): string
```

## Fix
- Change return type from `DBHTMLText` to `string`
- Cast `renderWith()` result to string
- Remove unused `DBHTMLText` import