### PR TITLE
fix: remove parent::onBeforeWrite() from FlexSlider Extension

### DIFF
--- a/src/ORM/FlexSlider.php
+++ b/src/ORM/FlexSlider.php
@@ -310,7 +310,6 @@ class FlexSlider extends Extension
      */
     public function onBeforeWrite()
     {
-        parent::onBeforeWrite();
 
         if (!$this->owner->CarouselThumbnailCt) {
             $this->owner->CarouselThumbnailCt = 6;


### PR DESCRIPTION
## Bug
SS6 `Extension` no longer has `onBeforeWrite()`. Calling `parent::onBeforeWrite()` causes fatal error.

## Fix
Remove `parent::onBeforeWrite()` call from `FlexSlider` extension.